### PR TITLE
Add travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,2 @@
+language: objective-c
+script: xcodebuild -workspace RosettaStoneKit.xcworkspace -scheme RosettaStoneKit -sdk iphonesimulator -destination "platform=iOS Simulator,name=iPhone 5" test

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ RosettaStoneKit is a magical Object Mapping framework. It converts dictionaries
 and arrays of data into instances of any classes. It can also convert your
 custom objects into dictionaries and arrays.
 
+[![Build Status](https://travis-ci.org/endoze/RosettaStoneKit.svg?branch=master)](https://travis-ci.org/endoze/RosettaStoneKit)
+
 ## Motivation
 
 There are other frameworks available that provide the same functionality, but

--- a/RosettaStoneKit.xcodeproj/xcshareddata/xcschemes/RosettaStoneKitOSXTests.xcscheme
+++ b/RosettaStoneKit.xcodeproj/xcshareddata/xcschemes/RosettaStoneKitOSXTests.xcscheme
@@ -1,0 +1,96 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0610"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "37C8E4031A7336C000A65E87"
+               BuildableName = "RosettaStoneKitOSXTests.xctest"
+               BlueprintName = "RosettaStoneKitOSXTests"
+               ReferencedContainer = "container:RosettaStoneKit.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      buildConfiguration = "Debug">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "37C8E4031A7336C000A65E87"
+               BuildableName = "RosettaStoneKitOSXTests.xctest"
+               BlueprintName = "RosettaStoneKitOSXTests"
+               ReferencedContainer = "container:RosettaStoneKit.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "37C8E4031A7336C000A65E87"
+            BuildableName = "RosettaStoneKitOSXTests.xctest"
+            BlueprintName = "RosettaStoneKitOSXTests"
+            ReferencedContainer = "container:RosettaStoneKit.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </TestAction>
+   <LaunchAction
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      buildConfiguration = "Debug"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "37C8E4031A7336C000A65E87"
+            BuildableName = "RosettaStoneKitOSXTests.xctest"
+            BlueprintName = "RosettaStoneKitOSXTests"
+            ReferencedContainer = "container:RosettaStoneKit.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      buildConfiguration = "Release"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "37C8E4031A7336C000A65E87"
+            BuildableName = "RosettaStoneKitOSXTests.xctest"
+            BlueprintName = "RosettaStoneKitOSXTests"
+            ReferencedContainer = "container:RosettaStoneKit.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/RosettaStoneKit.xcodeproj/xcshareddata/xcschemes/RosettaStoneKitTests.xcscheme
+++ b/RosettaStoneKit.xcodeproj/xcshareddata/xcschemes/RosettaStoneKitTests.xcscheme
@@ -1,0 +1,96 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0610"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "378177D51A686C6500B7E87E"
+               BuildableName = "RosettaStoneKitTests.xctest"
+               BlueprintName = "RosettaStoneKitTests"
+               ReferencedContainer = "container:RosettaStoneKit.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      buildConfiguration = "Debug">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "378177D51A686C6500B7E87E"
+               BuildableName = "RosettaStoneKitTests.xctest"
+               BlueprintName = "RosettaStoneKitTests"
+               ReferencedContainer = "container:RosettaStoneKit.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "378177D51A686C6500B7E87E"
+            BuildableName = "RosettaStoneKitTests.xctest"
+            BlueprintName = "RosettaStoneKitTests"
+            ReferencedContainer = "container:RosettaStoneKit.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </TestAction>
+   <LaunchAction
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      buildConfiguration = "Debug"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "378177D51A686C6500B7E87E"
+            BuildableName = "RosettaStoneKitTests.xctest"
+            BlueprintName = "RosettaStoneKitTests"
+            ReferencedContainer = "container:RosettaStoneKit.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      buildConfiguration = "Release"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "378177D51A686C6500B7E87E"
+            BuildableName = "RosettaStoneKitTests.xctest"
+            BlueprintName = "RosettaStoneKitTests"
+            ReferencedContainer = "container:RosettaStoneKit.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>


### PR DESCRIPTION
In order to allow tests to run on every pull request, this commit adds
a configuration file for travis. It also overwrites the script command
for running the tests so that we use xcodebuild instead of xctool.
