### PR TITLE
Remove branch from travis badge url

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ RosettaStoneKit is a magical Object Mapping framework. It converts dictionaries
 and arrays of data into instances of any classes. It can also convert your
 custom objects into dictionaries and arrays.
 
-[![Build Status](https://travis-ci.org/endoze/RosettaStoneKit.svg?branch=master)](https://travis-ci.org/endoze/RosettaStoneKit)
+[![Build Status](https://travis-ci.org/endoze/RosettaStoneKit.svg)](https://travis-ci.org/endoze/RosettaStoneKit)
 
 ## Motivation
 


### PR DESCRIPTION
This commit removes the branch parameter from the travis badge url. This
is because it defaults to master.
