### PR TITLE
Add twitter url in podspec

### DIFF
--- a/RosettaStoneKit.podspec
+++ b/RosettaStoneKit.podspec
@@ -11,7 +11,9 @@ Pod::Spec.new do |s|
 
   s.homepage     = "http://endoze.github.io/RosettaStoneKit"
   s.license      = {type: "MIT", file: "LICENSE"}
+
   s.author             = {"Chris" => "chris@wideeyelabs.com"}
+  s.social_media_url   = "https://twitter.com/endozemedia"
 
   s.ios.deployment_target = "8.0"
   s.osx.deployment_target = "10.10"


### PR DESCRIPTION
In order to add social media contact info to the library, this commit
adds the social_media_url attribute to the podspec.

[ci skip]
