### PR TITLE
Fix date parsing to and from objects

### DIFF
--- a/Common/RosettaStone.m
+++ b/Common/RosettaStone.m
@@ -217,7 +217,7 @@ static NSDateFormatter *defaultDateFormatter;
       Class keyClass = [propertyValue class];
     
       if (propertyValue) {
-        if ([keyClass isSubclassOfClass:[NSDate class]]) {
+        if ([propertyClass isSubclassOfClass:[NSDate class]] && ![propertyValue isEqual:[NSNull null]]) {
           NSString *dateString = [dictionary valueForKey:propertyName];
           NSDate *date = [[self dateFormatter] dateFromString:dateString];
           
@@ -260,7 +260,7 @@ static NSDateFormatter *defaultDateFormatter;
           NSDate *date = (NSDate *)propertyValue;
           NSString *dateString = [[self dateFormatter] stringFromDate:date];
           
-          [object setValue:dateString forKey:propertyName];
+          [dictionary setValue:dateString forKey:propertyName];
         } else if ([propertyClass isSubclassOfClass:[NSArray class]]) {
           NSMutableArray *results = [[NSMutableArray alloc] initWithCapacity:[propertyValue count]];
           

--- a/RosettaStoneKit/Info.plist
+++ b/RosettaStoneKit/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.2.0</string>
+	<string>1.2.1</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/RosettaStoneKitOSX/Info.plist
+++ b/RosettaStoneKitOSX/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.2.0</string>
+	<string>1.2.1</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/RosettaStoneKitOSXTests/Info.plist
+++ b/RosettaStoneKitOSXTests/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.2.0</string>
+	<string>1.2.1</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/RosettaStoneKitTests/Game.h
+++ b/RosettaStoneKitTests/Game.h
@@ -33,6 +33,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (nonatomic, copy) NSString *name;
 @property (nonatomic, strong) NSNumber *gameId;
+@property (nonatomic, strong) NSDate *date;
 
 @end
 

--- a/RosettaStoneKitTests/Info.plist
+++ b/RosettaStoneKitTests/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.2.0</string>
+	<string>1.2.1</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/RosettaStoneKitTests/RosettaStoneSpec.m
+++ b/RosettaStoneKitTests/RosettaStoneSpec.m
@@ -96,6 +96,17 @@ SpecBegin(RosettaStoneSpec)
         TestUser *user = [stone translate:userDictionary toClass:[TestUser class]];
         expect([user.games firstObject]).to.beInstanceOf([Game class]);
       });
+
+      it(@"should translate dates from strings", ^{
+        NSString *dateString = @"2015-10-15T19:24:40.669Z";
+        NSDateFormatter *dateFormatter = [NSDateFormatter new];
+        [dateFormatter setDateFormat:@"yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"];
+        NSDate *date = [dateFormatter dateFromString:dateString];
+        RosettaStone *stone = [RosettaStone sharedInstance];
+        NSDictionary *gameDictionary = @{@"name": @"foosball championship", @"gameId": @11, @"date": dateString};
+        Game *game = [stone translate:gameDictionary toClass:[Game class]];
+        expect([game date]).to.equal(date);
+      });
     });
     
     describe(@"translateToDictionary:", ^{
@@ -164,6 +175,19 @@ SpecBegin(RosettaStoneSpec)
            @{@"name": @"ping pong championship", @"gameId": @11}
         ];
         expect(userDictionary[@"games"]).to.equal(games);
+      });
+
+      it(@"should translate dates to strings", ^{
+        RosettaStone *stone = [RosettaStone sharedInstance];
+        NSDate *now = [NSDate new];
+        NSDateFormatter *dateFormatter = [NSDateFormatter new];
+        [dateFormatter setDateFormat:@"yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"];
+        Game *game = [Game new];
+        game.name = @"foosball championship";
+        game.date = now;
+        game.gameId = @25;
+        NSDictionary *gameDictionary = [stone translateToDictionary:game];
+        expect([gameDictionary objectForKey:@"date"]).to.equal([dateFormatter stringFromDate:now]);
       });
     });
     


### PR DESCRIPTION
In order to fix a bug where dates were not correctly translated back and
forth between string representations, this commit uses the propertyClass
and not the keyClass when checking for NSDate subclasses. This is
because we want to base the date translation on the property declaration
of a model and not the value from the dictionary (which is a string). In
addition, when translating back to dictionaries we set the dateString on
the dictionary we are returning and not the original object passed in.
