### PR TITLE
Add umbrella headers to podspec

### DIFF
--- a/RosettaStoneKit.podspec
+++ b/RosettaStoneKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "RosettaStoneKit"
-  s.version      = "1.2.1"
+  s.version      = "1.2.2"
   s.summary      = "Magical Object Mapping framework for iOS/OS X"
 
   s.description  = <<-DESC
@@ -20,7 +20,7 @@ Pod::Spec.new do |s|
   s.watchos.deployment_target = "2.0"
 
   s.source       = {git: "https://github.com/endoze/RosettaStoneKit.git", tag: "#{s.version}"}
-  s.source_files  = "Common", "Common/**/*.{h,m}"
+  s.source_files  = "Common", "Common/**/*.{h,m}", "RosettaStoneKit/RosettaStoneKit.h", "RosettaStoneKitOSX/RosettaStoneKitOSX.h"
 
   s.requires_arc = true
 end

--- a/RosettaStoneKit/Info.plist
+++ b/RosettaStoneKit/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.2.1</string>
+	<string>1.2.2</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/RosettaStoneKitOSX/Info.plist
+++ b/RosettaStoneKitOSX/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.2.1</string>
+	<string>1.2.2</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/RosettaStoneKitOSXTests/Info.plist
+++ b/RosettaStoneKitOSXTests/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.2.1</string>
+	<string>1.2.2</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/RosettaStoneKitTests/Info.plist
+++ b/RosettaStoneKitTests/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.2.1</string>
+	<string>1.2.2</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>


### PR DESCRIPTION
In order to ensure the umbrella headers are available in projects that
use this library via cocoapods, this commit includes the umbrella
headers in the source_files array.
