### PR TITLE
Add application extension api safe build setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,24 @@
 # Change Log
 
 ## 1.x Releases
+- `1.4.0` Releases - [1.4.0](#140)
 - `1.3.x` Releases - [1.3.0](#130) | [1.3.1](#131)
 - `1.2.x` Releases - [1.2.4](#124) | [1.2.3](#123) | [1.2.2](#122) | [1.2.1](#121) | [1.2.0](#120)
 - `1.1.x` Releases - [1.1.0](#110)
 - `1.0.x` Releases - [1.0.1](#101) | [1.0.0](#100)
 
 ---
+## [1.4.0](https://github.com/endoze/RosettaStoneKit/releases/tag/1.2.4)
+Released on 2015-03-10
+
+### Added
+
+### Updated
+- Changed APPLICATION_EXTENSION_API_ONLY build setting from NO to YES.
+
+### Removed
+
+
 
 ## [1.3.1](https://github.com/endoze/RosettaStoneKit/releases/tag/1.2.4)
 Released on 2015-03-02

--- a/RosettaStoneKit.podspec
+++ b/RosettaStoneKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "RosettaStoneKit"
-  s.version      = "1.3.1"
+  s.version      = "1.4.0"
   s.summary      = "Magical Object Mapping framework for iOS/OS X"
 
   s.description  = <<-DESC

--- a/RosettaStoneKit.xcodeproj/project.pbxproj
+++ b/RosettaStoneKit.xcodeproj/project.pbxproj
@@ -671,6 +671,7 @@
 		378177E21A686C6500B7E87E /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
@@ -689,6 +690,7 @@
 		378177E31A686C6500B7E87E /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;

--- a/RosettaStoneKit/Info.plist
+++ b/RosettaStoneKit/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.3.0</string>
+	<string>1.4.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/RosettaStoneKitOSX/Info.plist
+++ b/RosettaStoneKitOSX/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.3.0</string>
+	<string>1.4.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/RosettaStoneKitOSXTests/Info.plist
+++ b/RosettaStoneKitOSXTests/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.3.0</string>
+	<string>1.4.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/RosettaStoneKitTests/Info.plist
+++ b/RosettaStoneKitTests/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.3.0</string>
+	<string>1.4.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>


### PR DESCRIPTION
In order to allow this framework to build as part of an application
extension without throwing compiler warnings, this commit sets the
APPLICATION_EXTENSION_API_ONLY build setting to YES. Since this
framework only requires Foundation/Cocoa, this shouldn't cause any
problems and only enable it to be better utilized in application
extensions.
