### PR TITLE
Fix missing source files in podspec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Change Log
 
 ## 1.x Releases
-- `1.5.0` Releases - [1.5.0](#150)
+- `1.5.0` Releases - [1.5.0](#150) | [1.5.1](#151)
 - `1.4.0` Releases - [1.4.0](#140)
 - `1.3.x` Releases - [1.3.0](#130) | [1.3.1](#131)
 - `1.2.x` Releases - [1.2.4](#124) | [1.2.3](#123) | [1.2.2](#122) | [1.2.1](#121) | [1.2.0](#120)
@@ -9,6 +9,17 @@
 - `1.0.x` Releases - [1.0.1](#101) | [1.0.0](#100)
 
 ---
+## [1.5.1](https://github.com/endoze/RosettaStoneKit/releases/tag/1.5.0)
+Released on 2015-05-23
+
+### Added
+
+### Updated
+- Podspec source files to include library files
+
+### Removed
+
+
 ## [1.5.0](https://github.com/endoze/RosettaStoneKit/releases/tag/1.5.0)
 Released on 2015-05-22
 

--- a/RosettaStoneKit.podspec
+++ b/RosettaStoneKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "RosettaStoneKit"
-  s.version      = "1.5.0"
+  s.version      = "1.5.1"
   s.summary      = "Magical Object Mapping framework for iOS/OS X"
 
   s.description  = <<-DESC
@@ -20,7 +20,7 @@ Pod::Spec.new do |s|
   s.tvos.deployment_target = "9.0"
 
   s.source       = {git: "https://github.com/endoze/RosettaStoneKit.git", tag: "#{s.version}"}
-  s.source_files  = "Common", "Common/**/*.{h,m}", "RosettaStoneKit/RosettaStoneKit.h"
+  s.source_files  = "RosettaStoneKit/**/*.{h,m}"
 
   s.requires_arc = true
 end


### PR DESCRIPTION
In order to ensure that all source files for the project are
included, this commit changes the source_files podspec configuration to
include everything in the RosettaStoneKit directory.
