### PR TITLE
Update documentation header for framework

### DIFF
--- a/RosettaStoneKit/RosettaStone.h
+++ b/RosettaStoneKit/RosettaStone.h
@@ -44,8 +44,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 /*!
  @brief Register a new property translator with RosettaStone.
- @param propertyTranslater - The property translator you'd like to register with Rosetta Stone.
- @return void
+ @param propertyTranslator - The property translator you'd like to register with Rosetta Stone.
  */
 - (void)registerPropertyTranslator:(PropertyTranslator *)propertyTranslator;
 


### PR DESCRIPTION
In order to ensure documentation for the framework is correct, this
commit removes the return value from the registerPropertyTranslator:
method and fixes the misspelled param value.

[ci skip]